### PR TITLE
Create Flutter discipleship memorization app foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# New-First
-First repo
+# Discipleship Memorizer
+
+A Flutter application that equips followers of Jesus to grow through Scripture memorization, evangelism challenges, prayer focus, Bible reading plans, and journaling. The experience is designed for both mobile and web platforms.
+
+## Features
+
+- Choose from curated Scripture memory lists or build personal collections.
+- Guided memorization workflow that encourages speaking verses aloud and progressively hiding words with every press.
+- Daily reminders via local notifications and automatic refresh prompts to keep verses sharp.
+- Adjustable memorization pace with a 1–7 day slider for each verse.
+- Encouraging celebration when a verse is memorized.
+- Supplementary discipleship tools including:
+  - Daily evangelism challenges
+  - Prayer topics and checklists
+  - Bible reading plans
+  - Notes and journaling with quick entry
+
+## Getting Started
+
+1. Install the Flutter SDK and platform dependencies for mobile and web builds.
+2. Fetch packages:
+
+   ```sh
+   flutter pub get
+   ```
+
+3. Run the application on mobile or web:
+
+   ```sh
+   flutter run
+   ```
+
+   For web:
+
+   ```sh
+   flutter run -d chrome
+   ```
+
+4. Ensure notification permissions are granted on the target platform so daily reminders can be scheduled.
+
+## Project Structure
+
+- `lib/main.dart`: Application entry point with navigation.
+- `lib/models`: Core data models for verses and discipleship content.
+- `lib/providers`: State management for memorization and discipleship sections using Provider.
+- `lib/screens`: UI screens for each section of the app.
+- `lib/widgets`: Reusable components such as verse cards and celebration dialog.
+- `lib/services/notification_service.dart`: Wrapper around `flutter_local_notifications` for reminders and encouragements.
+
+## Assets
+
+Add text files or JSON in `assets/verses/` to import additional verse lists. Update `pubspec.yaml` if adding new assets or fonts.
+
+## Testing
+
+Run Flutter's test suite once widget and unit tests are authored:
+
+```sh
+flutter test
+```
+
+---
+
+This project intentionally avoids backend dependencies. Persisted state lives on the device via `SharedPreferences` while notifications use platform channels provided by Flutter.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    avoid_print: true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/memorization_provider.dart';
+import 'providers/discipleship_provider.dart';
+import 'screens/memorization/memorization_screen.dart';
+import 'screens/evangelism_screen.dart';
+import 'screens/prayer_screen.dart';
+import 'screens/reading_screen.dart';
+import 'screens/notes_screen.dart';
+import 'services/notification_service.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final notificationService = NotificationService();
+  await notificationService.init();
+
+  runApp(DiscipleshipApp(notificationService: notificationService));
+}
+
+class DiscipleshipApp extends StatelessWidget {
+  const DiscipleshipApp({super.key, required this.notificationService});
+
+  final NotificationService notificationService;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => MemorizationProvider(notificationService),
+        ),
+        ChangeNotifierProvider(create: (_) => DiscipleshipProvider()),
+      ],
+      child: MaterialApp(
+        title: 'Discipleship Coach',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+          useMaterial3: true,
+        ),
+        home: const _RootScaffold(),
+      ),
+    );
+  }
+}
+
+class _RootScaffold extends StatefulWidget {
+  const _RootScaffold();
+
+  @override
+  State<_RootScaffold> createState() => _RootScaffoldState();
+}
+
+class _RootScaffoldState extends State<_RootScaffold> {
+  int _currentIndex = 0;
+
+  static const _pages = [
+    MemorizationScreen(),
+    EvangelismScreen(),
+    PrayerScreen(),
+    ReadingScreen(),
+    NotesScreen(),
+  ];
+
+  static const _titles = [
+    'Memorize Scripture',
+    'Evangelism',
+    'Prayer',
+    'Bible Reading',
+    'Notes & Journaling',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final navigationBar = NavigationBar(
+      selectedIndex: _currentIndex,
+      destinations: const [
+        NavigationDestination(icon: Icon(Icons.menu_book), label: 'Verses'),
+        NavigationDestination(icon: Icon(Icons.campaign), label: 'Evangelism'),
+        NavigationDestination(icon: Icon(Icons.hands_clapping_outlined), label: 'Prayer'),
+        NavigationDestination(icon: Icon(Icons.auto_stories), label: 'Reading'),
+        NavigationDestination(icon: Icon(Icons.edit_note), label: 'Notes'),
+      ],
+      onDestinationSelected: (index) => setState(() => _currentIndex = index),
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_titles[_currentIndex]),
+      ),
+      body: _pages[_currentIndex],
+      bottomNavigationBar: navigationBar,
+    );
+  }
+}

--- a/lib/models/verse.dart
+++ b/lib/models/verse.dart
@@ -1,0 +1,83 @@
+import 'package:intl/intl.dart';
+
+class Verse {
+  Verse({
+    required this.id,
+    required this.reference,
+    required this.text,
+    this.translation = 'ESV',
+    int? daysToMemorize,
+    DateTime? startDate,
+    DateTime? nextReview,
+    this.completed = false,
+    this.hiddenWordCount = 0,
+  })  : daysToMemorize = daysToMemorize ?? 3,
+        startDate = startDate ?? DateTime.now(),
+        nextReview = nextReview ?? DateTime.now().add(const Duration(days: 1));
+
+  final String id;
+  final String reference;
+  final String text;
+  final String translation;
+  final int daysToMemorize;
+  final DateTime startDate;
+  DateTime nextReview;
+  bool completed;
+  int hiddenWordCount;
+
+  List<String> get words => text.split(RegExp(r'\s+'));
+
+  double get progress {
+    if (completed) {
+      return 1.0;
+    }
+    final total = daysToMemorize;
+    final elapsed = DateTime.now().difference(startDate).inDays.clamp(0, total);
+    return elapsed / total;
+  }
+
+  void markReviewed() {
+    nextReview = DateTime.now().add(const Duration(days: 1));
+  }
+
+  void markMemorized() {
+    completed = true;
+    hiddenWordCount = words.length;
+    nextReview = DateTime.now().add(const Duration(days: 7));
+  }
+
+  void scheduleRefresh({int days = 7}) {
+    nextReview = DateTime.now().add(Duration(days: days));
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'reference': reference,
+        'text': text,
+        'translation': translation,
+        'daysToMemorize': daysToMemorize,
+        'startDate': startDate.toIso8601String(),
+        'nextReview': nextReview.toIso8601String(),
+        'completed': completed,
+        'hiddenWordCount': hiddenWordCount,
+      };
+
+  factory Verse.fromJson(Map<String, dynamic> json) => Verse(
+        id: json['id'] as String,
+        reference: json['reference'] as String,
+        text: json['text'] as String,
+        translation: json['translation'] as String? ?? 'ESV',
+        daysToMemorize: json['daysToMemorize'] as int? ?? 3,
+        startDate: DateTime.tryParse(json['startDate'] as String? ?? '') ??
+            DateTime.now(),
+        nextReview: DateTime.tryParse(json['nextReview'] as String? ?? '') ??
+            DateTime.now().add(const Duration(days: 1)),
+        completed: json['completed'] as bool? ?? false,
+        hiddenWordCount: json['hiddenWordCount'] as int? ?? 0,
+      );
+
+  String formattedNextReview() {
+    final formatter = DateFormat.yMMMd();
+    return formatter.format(nextReview);
+  }
+}

--- a/lib/models/verse_list.dart
+++ b/lib/models/verse_list.dart
@@ -1,0 +1,37 @@
+import 'verse.dart';
+
+enum VerseListType {
+  curated,
+  custom,
+}
+
+class VerseList {
+  VerseList({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.type,
+    List<Verse>? verses,
+  }) : verses = verses ?? <Verse>[];
+
+  final String id;
+  final String title;
+  final String description;
+  final VerseListType type;
+  final List<Verse> verses;
+
+  double get progress {
+    if (verses.isEmpty) {
+      return 0;
+    }
+    final completed = verses.where((verse) => verse.completed).length;
+    return completed / verses.length;
+  }
+
+  Verse? nextIncompleteVerse() {
+    return verses.firstWhere(
+      (verse) => !verse.completed,
+      orElse: () => verses.isEmpty ? null : verses.first,
+    );
+  }
+}

--- a/lib/providers/discipleship_provider.dart
+++ b/lib/providers/discipleship_provider.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/foundation.dart';
+
+class EvangelismChallenge {
+  EvangelismChallenge({
+    required this.title,
+    required this.description,
+    this.completed = false,
+  });
+
+  final String title;
+  final String description;
+  bool completed;
+}
+
+class PrayerTopic {
+  PrayerTopic({
+    required this.title,
+    required this.description,
+    this.completed = false,
+  });
+
+  final String title;
+  final String description;
+  bool completed;
+}
+
+class BibleReadingPlan {
+  BibleReadingPlan({
+    required this.title,
+    required this.passage,
+    this.completed = false,
+  });
+
+  final String title;
+  final String passage;
+  bool completed;
+}
+
+class JournalEntry {
+  JournalEntry({
+    required this.title,
+    required this.content,
+    required this.date,
+  });
+
+  final String title;
+  final String content;
+  final DateTime date;
+}
+
+class DiscipleshipProvider extends ChangeNotifier {
+  DiscipleshipProvider();
+
+  final List<EvangelismChallenge> challenges = [
+    EvangelismChallenge(
+      title: 'Share Your Testimony',
+      description: 'Tell a friend how you came to know Jesus.',
+    ),
+    EvangelismChallenge(
+      title: 'Pray for Opportunities',
+      description: 'Spend five minutes praying for boldness and open doors.',
+    ),
+  ];
+
+  final List<PrayerTopic> prayerTopics = [
+    PrayerTopic(
+      title: 'Family',
+      description: 'Lift up each member of your family by name today.',
+    ),
+    PrayerTopic(
+      title: 'Church',
+      description: 'Pray for your church leaders and volunteers.',
+    ),
+  ];
+
+  final List<BibleReadingPlan> readingPlans = [
+    BibleReadingPlan(
+      title: 'Gospel of John',
+      passage: 'Read John 1-2 today.',
+    ),
+    BibleReadingPlan(
+      title: 'Psalms of Praise',
+      passage: 'Read Psalm 95 and 100.',
+    ),
+  ];
+
+  final List<JournalEntry> journalEntries = [];
+
+  void toggleChallenge(EvangelismChallenge challenge) {
+    challenge.completed = !challenge.completed;
+    notifyListeners();
+  }
+
+  void togglePrayerTopic(PrayerTopic topic) {
+    topic.completed = !topic.completed;
+    notifyListeners();
+  }
+
+  void toggleReadingPlan(BibleReadingPlan plan) {
+    plan.completed = !plan.completed;
+    notifyListeners();
+  }
+
+  void addJournalEntry(String title, String content) {
+    journalEntries.add(
+      JournalEntry(title: title, content: content, date: DateTime.now()),
+    );
+    notifyListeners();
+  }
+}

--- a/lib/providers/memorization_provider.dart
+++ b/lib/providers/memorization_provider.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/verse.dart';
+import '../models/verse_list.dart';
+import '../services/notification_service.dart';
+
+class MemorizationProvider extends ChangeNotifier {
+  MemorizationProvider(this._notificationService) {
+    _loadInitialData();
+  }
+
+  final NotificationService _notificationService;
+  final _uuid = const Uuid();
+  final List<VerseList> _lists = [];
+
+  List<VerseList> get lists => List.unmodifiable(_lists);
+
+  Verse? _activeVerse;
+  Verse? get activeVerse => _activeVerse;
+
+  Future<void> _loadInitialData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString('memorization_data');
+    if (stored != null) {
+      final List<dynamic> decoded = jsonDecode(stored) as List<dynamic>;
+      _lists
+        ..clear()
+        ..addAll(decoded.map((dynamic item) {
+          final map = item as Map<String, dynamic>;
+          return VerseList(
+            id: map['id'] as String,
+            title: map['title'] as String,
+            description: map['description'] as String,
+            type: VerseListType.values[map['type'] as int? ?? 0],
+            verses: (map['verses'] as List<dynamic>? ?? <dynamic>[])
+                .map((dynamic verse) =>
+                    Verse.fromJson(verse as Map<String, dynamic>))
+                .toList(),
+          );
+        }));
+    } else {
+      _lists.addAll(_defaultLists());
+    }
+    await _scheduleDailyReminder();
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = _lists
+        .map((list) => {
+              'id': list.id,
+              'title': list.title,
+              'description': list.description,
+              'type': list.type.index,
+              'verses': list.verses.map((verse) => verse.toJson()).toList(),
+            })
+        .toList();
+    await prefs.setString('memorization_data', jsonEncode(data));
+  }
+
+  Future<void> _scheduleDailyReminder() async {
+    final verse = _activeVerse ?? nextVerseToPractice();
+    if (verse != null) {
+      await _notificationService.scheduleDailyPractice(verse);
+    }
+  }
+
+  List<VerseList> _defaultLists() {
+    return [
+      VerseList(
+        id: 'faith',
+        title: 'Faith Builders',
+        description: 'Foundational verses about trusting God.',
+        type: VerseListType.curated,
+        verses: [
+          Verse(
+            id: _uuid.v4(),
+            reference: 'Proverbs 3:5-6',
+            text:
+                'Trust in the LORD with all your heart, and do not lean on your own understanding. In all your ways acknowledge him, and he will make straight your paths.',
+          ),
+          Verse(
+            id: _uuid.v4(),
+            reference: 'Philippians 4:6-7',
+            text:
+                'Do not be anxious about anything, but in everything by prayer and supplication with thanksgiving let your requests be made known to God. And the peace of God, which surpasses all understanding, will guard your hearts and your minds in Christ Jesus.',
+          ),
+        ],
+      ),
+      VerseList(
+        id: 'identity',
+        title: 'Identity in Christ',
+        description: 'Reminders of who we are in Christ Jesus.',
+        type: VerseListType.curated,
+        verses: [
+          Verse(
+            id: _uuid.v4(),
+            reference: '2 Corinthians 5:17',
+            text:
+                'Therefore, if anyone is in Christ, he is a new creation. The old has passed away; behold, the new has come.',
+          ),
+          Verse(
+            id: _uuid.v4(),
+            reference: 'Galatians 2:20',
+            text:
+                'I have been crucified with Christ. It is no longer I who live, but Christ who lives in me. And the life I now live in the flesh I live by faith in the Son of God, who loved me and gave himself for me.',
+          ),
+        ],
+      ),
+    ];
+  }
+
+  Verse? nextVerseToPractice() {
+    for (final list in _lists) {
+      final verse = list.nextIncompleteVerse();
+      if (verse != null && !verse.completed) {
+        return verse;
+      }
+    }
+    return null;
+  }
+
+  void startPractice(Verse verse) {
+    _activeVerse = verse;
+    _scheduleDailyReminder();
+    notifyListeners();
+  }
+
+  Future<void> updateDaysToMemorize(Verse verse, int days) async {
+    verse.hiddenWordCount = 0;
+    verse.completed = false;
+    verse.nextReview = DateTime.now().add(const Duration(days: 1));
+    await _notificationService.scheduleDailyPractice(verse);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> advanceHiddenWords(Verse verse) async {
+    if (verse.hiddenWordCount < verse.words.length) {
+      verse.hiddenWordCount += (verse.words.length / 4).ceil();
+      if (verse.hiddenWordCount > verse.words.length) {
+        verse.hiddenWordCount = verse.words.length;
+      }
+      await _persist();
+      notifyListeners();
+    }
+  }
+
+  Future<void> revealWords(Verse verse) async {
+    if (verse.hiddenWordCount > 0) {
+      verse.hiddenWordCount = (verse.hiddenWordCount - (verse.words.length / 4).ceil())
+          .clamp(0, verse.words.length);
+      await _persist();
+      notifyListeners();
+    }
+  }
+
+  Future<void> markMemorized(Verse verse) async {
+    verse.markMemorized();
+    await _notificationService.showCelebration(verse);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> scheduleRefresh(Verse verse, {int days = 7}) async {
+    verse.scheduleRefresh(days: days);
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> addCustomVerse({
+    required String reference,
+    required String text,
+    int daysToMemorize = 3,
+  }) async {
+    VerseList? customList =
+        _lists.firstWhere((list) => list.type == VerseListType.custom, orElse: () {
+      final list = VerseList(
+        id: 'custom',
+        title: 'My Verses',
+        description: 'Verses you have added.',
+        type: VerseListType.custom,
+      );
+      _lists.add(list);
+      return list;
+    });
+
+    final verse = Verse(
+      id: _uuid.v4(),
+      reference: reference,
+      text: text,
+      daysToMemorize: daysToMemorize,
+    );
+    customList.verses.add(verse);
+    await _persist();
+    notifyListeners();
+  }
+}

--- a/lib/screens/evangelism_screen.dart
+++ b/lib/screens/evangelism_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/discipleship_provider.dart';
+
+class EvangelismScreen extends StatelessWidget {
+  const EvangelismScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<DiscipleshipProvider>();
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: provider.challenges.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final challenge = provider.challenges[index];
+        return Card(
+          child: ListTile(
+            title: Text(challenge.title),
+            subtitle: Text(challenge.description),
+            trailing: Checkbox(
+              value: challenge.completed,
+              onChanged: (_) => provider.toggleChallenge(challenge),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/memorization/create_custom_verse_screen.dart
+++ b/lib/screens/memorization/create_custom_verse_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/memorization_provider.dart';
+
+class CreateCustomVerseScreen extends StatefulWidget {
+  const CreateCustomVerseScreen({super.key});
+
+  @override
+  State<CreateCustomVerseScreen> createState() => _CreateCustomVerseScreenState();
+}
+
+class _CreateCustomVerseScreenState extends State<CreateCustomVerseScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _referenceController = TextEditingController();
+  final _textController = TextEditingController();
+  double _days = 3;
+
+  @override
+  void dispose() {
+    _referenceController.dispose();
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Custom Verse')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _referenceController,
+                decoration: const InputDecoration(
+                  labelText: 'Reference',
+                  hintText: 'e.g. John 3:16',
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter the reference';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _textController,
+                maxLines: 5,
+                decoration: const InputDecoration(
+                  labelText: 'Verse Text',
+                  alignLabelWithHint: true,
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter the verse text';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              Text('Days to memorize: ${_days.round()}'),
+              Slider(
+                value: _days,
+                min: 1,
+                max: 7,
+                divisions: 6,
+                label: _days.round().toString(),
+                onChanged: (value) => setState(() => _days = value),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () async {
+                  if (_formKey.currentState!.validate()) {
+                    await context.read<MemorizationProvider>().addCustomVerse(
+                          reference: _referenceController.text.trim(),
+                          text: _textController.text.trim(),
+                          daysToMemorize: _days.round(),
+                        );
+                    if (mounted) {
+                      Navigator.of(context).pop();
+                    }
+                  }
+                },
+                child: const Text('Save Verse'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/memorization/memorization_screen.dart
+++ b/lib/screens/memorization/memorization_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/verse.dart';
+import '../../models/verse_list.dart';
+import '../../providers/memorization_provider.dart';
+import '../../widgets/verse_list_card.dart';
+import '../../widgets/celebration_dialog.dart';
+import 'create_custom_verse_screen.dart';
+import 'verse_detail_screen.dart';
+
+class MemorizationScreen extends StatelessWidget {
+  const MemorizationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MemorizationProvider>(
+      builder: (context, provider, _) {
+        return Scaffold(
+          body: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+            itemCount: provider.lists.length,
+            itemBuilder: (context, index) {
+              final list = provider.lists[index];
+              return VerseListCard(
+                verseList: list,
+                onPractice: (Verse verse) {
+                  provider.startPractice(verse);
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => VerseDetailScreen(verse: verse, verseList: list),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+          floatingActionButton: FloatingActionButton.extended(
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const CreateCustomVerseScreen(),
+              ),
+            ),
+            icon: const Icon(Icons.add),
+            label: const Text('Add Verse'),
+          ),
+        );
+      },
+    );
+  }
+}
+
+Future<void> showMemorizedCelebration(BuildContext context, Verse verse) async {
+  await showDialog<void>(
+    context: context,
+    builder: (_) => CelebrationDialog(verse: verse),
+  );
+}

--- a/lib/screens/memorization/verse_detail_screen.dart
+++ b/lib/screens/memorization/verse_detail_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/verse.dart';
+import '../../models/verse_list.dart';
+import '../../providers/memorization_provider.dart';
+import '../../widgets/hideable_text.dart';
+import '../memorization/memorization_screen.dart';
+
+class VerseDetailScreen extends StatefulWidget {
+  const VerseDetailScreen({super.key, required this.verse, required this.verseList});
+
+  final Verse verse;
+  final VerseList verseList;
+
+  @override
+  State<VerseDetailScreen> createState() => _VerseDetailScreenState();
+}
+
+class _VerseDetailScreenState extends State<VerseDetailScreen> {
+  double? _days;
+
+  @override
+  void initState() {
+    super.initState();
+    _days = widget.verse.daysToMemorize.toDouble();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<MemorizationProvider>();
+    final verse = widget.verse;
+
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: [
+          SliverAppBar.large(
+            title: Text(verse.reference),
+            flexibleSpace: FlexibleSpaceBar(
+              background: Container(
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [Color(0xFF0A6E6D), Color(0xFF118B8A)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Text(
+                      widget.verseList.title,
+                      style: Theme.of(context)
+                          .textTheme
+                          .headlineSmall
+                          ?.copyWith(color: Colors.white),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.all(24),
+            sliver: SliverList.list(
+              children: [
+                Card(
+                  elevation: 2,
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Speak the verse out loud:',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 16),
+                        HideableText(verse: verse),
+                        const SizedBox(height: 24),
+                        Wrap(
+                          spacing: 12,
+                          children: [
+                            FilledButton.icon(
+                              onPressed: () => provider.advanceHiddenWords(verse),
+                              icon: const Icon(Icons.visibility_off),
+                              label: const Text('Hide more'),
+                            ),
+                            OutlinedButton.icon(
+                              onPressed: () => provider.revealWords(verse),
+                              icon: const Icon(Icons.visibility),
+                              label: const Text('Reveal'),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Card(
+                  elevation: 2,
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Practice pace',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 16),
+                        Text('Days to memorize: ${_days?.round()}'),
+                        Slider(
+                          value: _days ?? 3,
+                          min: 1,
+                          max: 7,
+                          divisions: 6,
+                          label: _days?.round().toString(),
+                          onChanged: (value) => setState(() => _days = value),
+                          onChangeEnd: (value) => provider.updateDaysToMemorize(
+                            verse,
+                            value.round(),
+                          ),
+                        ),
+                        Text(
+                          'Next review: ${verse.formattedNextReview()}',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Card(
+                  elevation: 2,
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Ready for review tomorrow?',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'We will remind you to quote this verse again tomorrow. '
+                          'If it has been a while, choose a refresh interval below.',
+                        ),
+                        const SizedBox(height: 16),
+                        FilledButton(
+                          onPressed: () async {
+                            await provider.markMemorized(verse);
+                            if (mounted) {
+                              await showMemorizedCelebration(context, verse);
+                            }
+                          },
+                          child: const Text('I have memorized this verse'),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Set a refresh reminder (days):',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            for (final days in [3, 7, 14, 30])
+                              ChoiceChip(
+                                label: Text('$days'),
+                                selected: verse.nextReview
+                                        .difference(DateTime.now())
+                                        .inDays ==
+                                    days,
+                                onSelected: (_) => provider.scheduleRefresh(
+                                  verse,
+                                  days: days,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/notes_screen.dart
+++ b/lib/screens/notes_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/discipleship_provider.dart';
+
+class NotesScreen extends StatefulWidget {
+  const NotesScreen({super.key});
+
+  @override
+  State<NotesScreen> createState() => _NotesScreenState();
+}
+
+class _NotesScreenState extends State<NotesScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _contentController = TextEditingController();
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<DiscipleshipProvider>();
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: provider.journalEntries.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final entry = provider.journalEntries[index];
+              return Card(
+                child: ListTile(
+                  title: Text(entry.title),
+                  subtitle: Text(
+                    entry.content,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: Text(
+                    '${entry.date.month}/${entry.date.day}/${entry.date.year}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(labelText: 'Entry title'),
+                  validator: (value) =>
+                      value == null || value.isEmpty ? 'Please add a title' : null,
+                ),
+                const SizedBox(height: 8),
+                TextFormField(
+                  controller: _contentController,
+                  maxLines: 4,
+                  decoration: const InputDecoration(
+                    labelText: 'What is God teaching you?',
+                    alignLabelWithHint: true,
+                  ),
+                  validator: (value) => value == null || value.isEmpty
+                      ? 'Share a thought or prayer.'
+                      : null,
+                ),
+                const SizedBox(height: 12),
+                FilledButton.icon(
+                  onPressed: () {
+                    if (_formKey.currentState!.validate()) {
+                      provider.addJournalEntry(
+                        _titleController.text.trim(),
+                        _contentController.text.trim(),
+                      );
+                      _titleController.clear();
+                      _contentController.clear();
+                    }
+                  },
+                  icon: const Icon(Icons.save),
+                  label: const Text('Save entry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screens/prayer_screen.dart
+++ b/lib/screens/prayer_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/discipleship_provider.dart';
+
+class PrayerScreen extends StatelessWidget {
+  const PrayerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<DiscipleshipProvider>();
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: provider.prayerTopics.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final topic = provider.prayerTopics[index];
+        return Card(
+          child: ListTile(
+            title: Text(topic.title),
+            subtitle: Text(topic.description),
+            trailing: Checkbox(
+              value: topic.completed,
+              onChanged: (_) => provider.togglePrayerTopic(topic),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/reading_screen.dart
+++ b/lib/screens/reading_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/discipleship_provider.dart';
+
+class ReadingScreen extends StatelessWidget {
+  const ReadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<DiscipleshipProvider>();
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: provider.readingPlans.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final plan = provider.readingPlans[index];
+        return Card(
+          child: ListTile(
+            title: Text(plan.title),
+            subtitle: Text(plan.passage),
+            trailing: Checkbox(
+              value: plan.completed,
+              onChanged: (_) => provider.toggleReadingPlan(plan),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../models/verse.dart';
+
+class NotificationService {
+  NotificationService() : _plugin = FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const settings = InitializationSettings(android: android);
+    await _plugin.initialize(settings);
+  }
+
+  Future<void> scheduleDailyPractice(Verse verse) async {
+    final details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'daily_practice',
+        'Daily Practice',
+        channelDescription:
+            'Daily reminders to review your current memory verse.',
+        importance: Importance.max,
+        priority: Priority.high,
+      ),
+    );
+
+    await _plugin.showDailyAtTime(
+      1,
+      'Practice ${verse.reference}',
+      verse.text,
+      const Time(8, 0, 0),
+      details,
+    );
+  }
+
+  Future<void> showCelebration(Verse verse) async {
+    final details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        'celebration',
+        'Memorization Celebrations',
+        channelDescription: 'Encouraging notifications when you memorize verses.',
+        importance: Importance.high,
+        priority: Priority.high,
+      ),
+    );
+
+    await _plugin.show(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      'Well done!',
+      'You just memorized ${verse.reference}! Keep going!',
+      details,
+    );
+  }
+}

--- a/lib/widgets/celebration_dialog.dart
+++ b/lib/widgets/celebration_dialog.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../models/verse.dart';
+
+class CelebrationDialog extends StatefulWidget {
+  const CelebrationDialog({super.key, required this.verse});
+
+  final Verse verse;
+
+  @override
+  State<CelebrationDialog> createState() => _CelebrationDialogState();
+}
+
+class _CelebrationDialogState extends State<CelebrationDialog>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+    _scale = CurvedAnimation(parent: _controller, curve: Curves.elasticOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: _scale,
+      child: AlertDialog(
+        title: const Text('Great job!'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.celebration,
+              color: Theme.of(context).colorScheme.primary,
+              size: 72,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'You have memorized ${widget.verse.reference}! Keep hiding God\'s word in your heart.',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Celebrate'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/hideable_text.dart
+++ b/lib/widgets/hideable_text.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../models/verse.dart';
+
+class HideableText extends StatelessWidget {
+  const HideableText({super.key, required this.verse});
+
+  final Verse verse;
+
+  @override
+  Widget build(BuildContext context) {
+    final words = verse.words;
+    final hiddenCount = verse.hiddenWordCount.clamp(0, words.length);
+    final visibleWords = [
+      ...words.sublist(0, words.length - hiddenCount),
+      ...List.filled(hiddenCount, '____'),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          visibleWords.join(' '),
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        Text(
+          verse.translation,
+          style: Theme.of(context)
+              .textTheme
+              .labelMedium
+              ?.copyWith(color: Theme.of(context).colorScheme.secondary),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/verse_list_card.dart
+++ b/lib/widgets/verse_list_card.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+import '../models/verse.dart';
+import '../models/verse_list.dart';
+
+class VerseListCard extends StatelessWidget {
+  const VerseListCard({
+    super.key,
+    required this.verseList,
+    required this.onPractice,
+  });
+
+  final VerseList verseList;
+  final ValueChanged<Verse> onPractice;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    verseList.title,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                ),
+                SizedBox(
+                  width: 60,
+                  height: 60,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      CircularProgressIndicator(
+                        value: verseList.progress,
+                        backgroundColor:
+                            Theme.of(context).colorScheme.surfaceVariant,
+                      ),
+                      Center(
+                        child: Text('${(verseList.progress * 100).round()}%'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              verseList.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: verseList.verses.map((verse) {
+                return ActionChip(
+                  label: Text(verse.reference),
+                  avatar: Icon(
+                    verse.completed ? Icons.check_circle : Icons.circle_outlined,
+                    color: verse.completed
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).colorScheme.outline,
+                  ),
+                  onPressed: () => onPractice(verse),
+                );
+              }).toList(),
+            ),
+            if (verseList.verses.isEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Text(
+                  'Add a verse to get started.',
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Theme.of(context).colorScheme.outline),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,30 @@
+name: discipleship_memorizer
+description: >-
+  A cross-platform Flutter app for Christian discipleship, verse memorization,
+  evangelism challenges, prayer topics, Bible reading plans, and journaling.
+version: 0.1.0+1
+publish_to: 'none'
+
+environment:
+  sdk: '>=3.2.3 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  provider: ^6.1.2
+  shared_preferences: ^2.2.2
+  flutter_local_notifications: ^16.3.2
+  intl: ^0.19.0
+  uuid: ^4.3.3
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/verses/
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+


### PR DESCRIPTION
## Summary
- scaffold a Flutter application for Scripture memorization, evangelism challenges, prayer focuses, Bible reading, and journaling
- implement models, providers, and widgets for verse practice with progressive hiding, memorization pacing, and celebrations
- add navigation, discipleship feature screens, and a notification service with daily practice reminders

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d7a2d91483298130bd8e7a1ef8c9